### PR TITLE
Improve Sudoku digit recognition pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+extracted_cells/
+extracted_cells_bin/
+*_edges.jpg
+*_thresh.jpg
+*_largest.jpg
+*_rectified*.jpg
+digit_knn_opencv.npz
+sudoku_grid.npy
+*.log


### PR DESCRIPTION
## Summary
- Use custom HOG+KNN digit classifier with OCR fallback for unrecognized cells
- Relax OCR preprocessing: safer border cropping and majority vote digit selection
- Ignore generated artifacts via `.gitignore`

## Testing
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68af7c11072c8333aecb50eede1f40fe